### PR TITLE
Removing references to the fusion-dev repo in the build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,16 +15,6 @@ subprojects {
     targetCompatibility = 1.8
 
     repositories {
-        maven {
-            credentials {
-                username = "${lucidArtifactoryUsername}"
-                password = "${lucidArtifactoryPassword}"
-            }
-            authentication {
-                basic(BasicAuthentication)
-            }
-            url "https://artifactory.lucidworks.com/artifactory/fusion-dev/"
-        }
         mavenCentral()
         mavenLocal()
         maven {
@@ -37,24 +27,4 @@ subprojects {
         testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     }
 
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                from components.java
-            }
-        }
-        repositories {
-            mavenLocal()
-            maven {
-                url project.hasProperty('repositoryUrl') ? project.property('repositoryUrl') : ''
-                credentials {
-                    username project.hasProperty('lucidArtifactoryUsername') ? project.property('lucidArtifactoryUsername') : ''
-                    password project.hasProperty('lucidArtifactoryPassword') ? project.property('lucidArtifactoryPassword') : ''
-                }
-                authentication {
-                    basic(BasicAuthentication)
-                }
-            }
-        }
-    }
 }

--- a/examples/sample-plugin-stage/build.gradle
+++ b/examples/sample-plugin-stage/build.gradle
@@ -1,16 +1,6 @@
 apply plugin: 'java-library'
 
 repositories {
-    maven {
-        credentials {
-            username = "${lucidArtifactoryUsername}"
-            password = "${lucidArtifactoryPassword}"
-        }
-        authentication {
-            basic(BasicAuthentication)
-        }
-        url "https://artifactory.lucidworks.com/artifactory/fusion-dev/"
-    }
     mavenLocal()
     mavenCentral()
     maven {


### PR DESCRIPTION
The fusion-dev repository shouldn't be part of the build.gradle considering this is a public release.
Devs can add the reference for their own testing if they need. 

This also caused and issue because someone pushed an incorrect image of the search-dsl which broke the build for internal devs using the repo. 
```
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve com.lucidworks.cloud:search-dsl:6.+.
     Required by:
         project :
         project : > com.lucidworks-plugins.query-stage-sdk:query-stage-plugin-sdk:1.1.0-SNAPSHOT:20220424.052839-162
      > Unable to find a matching variant of com.lucidworks.cloud:search-dsl:6.3.4-SEARCH-1200-SNAPSHOT:20220509.202702-1:
```